### PR TITLE
Revert "Pin catalog base images (#210)"

### DIFF
--- a/Dockerfile-4.12.catalog
+++ b/Dockerfile-4.12.catalog
@@ -1,5 +1,5 @@
 # The base image is expected to contain /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM registry.redhat.io/openshift4/ose-operator-registry:v4.12@sha256:e995b555d2cc390ddadc2193bd3b2a954fddafbbf687cb40cb01f9e0a199910e
+FROM registry.redhat.io/openshift4/ose-operator-registry:v4.12
 
 ENTRYPOINT ["/bin/opm"]
 CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]

--- a/Dockerfile-4.13.catalog
+++ b/Dockerfile-4.13.catalog
@@ -1,5 +1,5 @@
 # The base image is expected to contain /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM registry.redhat.io/openshift4/ose-operator-registry:v4.13@sha256:acf5365731e9fbc83f7cbb416558f9850bbbb5bb3318c6cbba2b8520a446751d
+FROM registry.redhat.io/openshift4/ose-operator-registry:v4.13
 
 ENTRYPOINT ["/bin/opm"]
 CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]

--- a/Dockerfile-4.14.catalog
+++ b/Dockerfile-4.14.catalog
@@ -1,5 +1,5 @@
 # The base image is expected to contain /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM registry.redhat.io/openshift4/ose-operator-registry:v4.14@sha256:6e23bde58585b5e4fbd493365d36e570aae24aaea6e3ff0c7fbed7a1bacc5fb6
+FROM registry.redhat.io/openshift4/ose-operator-registry:v4.14
 
 ENTRYPOINT ["/bin/opm"]
 CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]

--- a/Dockerfile-4.15.catalog
+++ b/Dockerfile-4.15.catalog
@@ -1,5 +1,5 @@
 # The base image is expected to contain /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.15@sha256:85695a81d36ab7aa37a53cc8f371fb6ea60c9e749ad81ed1122813c607712dbf
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.15
 
 ENTRYPOINT ["/bin/opm"]
 CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]

--- a/Dockerfile-4.16.catalog
+++ b/Dockerfile-4.16.catalog
@@ -1,5 +1,5 @@
 # The base image is expected to contain /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.16@sha256:36522c63919b43a726870de6608a760d280b08dcd559ecd46a2700b86bff8fe9
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.16
 
 ENTRYPOINT ["/bin/opm"]
 CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]

--- a/Dockerfile-4.17.catalog
+++ b/Dockerfile-4.17.catalog
@@ -1,5 +1,5 @@
 # The base image is expected to contain /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.17@sha256:36765a1811111d44b9d69dcd10c85863615a513c409972ea9ec54db9cf6ce3ce
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.17
 
 ENTRYPOINT ["/bin/opm"]
 CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]

--- a/README.md
+++ b/README.md
@@ -14,16 +14,18 @@ podman build -t docker.io/user/jaeger-operator:$(date +%s) -f Dockerfile.operato
 ```
 
 ## Release
+### Application
+Update all base images (merge renovatebot PRs).
 
-Create a PR `Release - update upstream sources x.y`
-1. Update all base images
+Create a PR `Release - update upstream sources x.y`:
+1. Update git submodules with upstream versions
 1. Update rpm lockfiles
    ```bash
    rpm-lockfile-prototype --arch x86_64 --arch aarch64 --arch s390x --arch ppc64le -f Dockerfile.operator rpms.in.yaml --outfile rpms.lock.yaml
    cd bundle-patch; rpm-lockfile-prototype --arch x86_64 rpms.in.yaml --outfile rpms.lock.yaml
    ```
-1. Update git submodules with upstream versions
 
+### Bundle
 Wait for renovatebot to create PRs to update the hash in the `bundle-patch/update_bundle.sh` file, and merge all of them.
 
 Create a PR `Release - update bundle version x.y` and update [patch_csv.yaml](./bundle-patch/patch_csv.yaml) by submitting a PR with follow-up changes:
@@ -39,6 +41,7 @@ Create a PR `Release - update bundle version x.y` and update [patch_csv.yaml](./
    rm jaeger-operator.clusterserviceversion.yaml
    ```
 
+### Catalog
 Once the PR is merged and bundle is built, create another PR `Release - update catalog x.y` with:
 * Updated [catalog template](./catalog/catalog-template.yaml) with the new bundle (get the bundle pullspec from [Konflux](https://console.redhat.com/application-pipeline/workspaces/rhosdt/applications/jaeger/components/jaeger-bundle)):
    ```bash


### PR DESCRIPTION
We don't ship the catalog image (it gets merged with the existing OCP one), and the images are explicitly excluded in the renovatebot config.

This reverts commit 5eef1e0b88daf1662bad1be50fe3ca9c11be56c8.