### PR TITLE
fix(KONFLUX-6218): align repository ids to cpe mapping

### DIFF
--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -5,28 +5,28 @@ arches:
 - arch: aarch64
   packages:
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/o/openssl-1.1.1k-14.el8_6.aarch64.rpm
-    repoid: ubi-8-baseos-rpms
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 708628
     checksum: sha256:1367e3cc6f59b4afa0a326455e2c381f7b5b9ca00e5de86663895cdaec70e52b
     name: openssl
     evr: 1:1.1.1k-14.el8_6
     sourcerpm: openssl-1.1.1k-14.el8_6.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/patch-2.7.6-11.el8.aarch64.rpm
-    repoid: ubi-8-baseos-rpms
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 137068
     checksum: sha256:df4e0ff529277632828222b4ad22583155c56c5fbbf95c964018ae1180d60c3a
     name: patch
     evr: 2.7.6-11.el8
     sourcerpm: patch-2.7.6-11.el8.src.rpm
   source:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/source/SRPMS/Packages/o/openssl-1.1.1k-14.el8_6.src.rpm
-    repoid: ubi-8-baseos-source
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/source/SRPMS/Packages/o/openssl-1.1.1k-14.el8_6.src.rpm
+    repoid: ubi-8-for-x86_64-baseos-source-rpms
     size: 7741480
     checksum: sha256:c97b10d6a034e025a19ec8443ef7c80755e3a407fe29a77dda95af958b199eed
     name: openssl
     evr: 1:1.1.1k-14.el8_6
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/source/SRPMS/Packages/p/patch-2.7.6-11.el8.src.rpm
-    repoid: ubi-8-baseos-source
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/source/SRPMS/Packages/p/patch-2.7.6-11.el8.src.rpm
+    repoid: ubi-8-for-x86_64-baseos-source-rpms
     size: 818532
     checksum: sha256:1dbc060aa6adf18b5269f0f878ebf26a4b3da0edd92b3bc2c152072b9ba72b61
     name: patch
@@ -35,28 +35,28 @@ arches:
 - arch: ppc64le
   packages:
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/o/openssl-1.1.1k-14.el8_6.ppc64le.rpm
-    repoid: ubi-8-baseos-rpms
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 731808
     checksum: sha256:13616f555100e3a9b4617fe4d3aa13c4a1f46237708572b379749863ee1fb7ae
     name: openssl
     evr: 1:1.1.1k-14.el8_6
     sourcerpm: openssl-1.1.1k-14.el8_6.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/patch-2.7.6-11.el8.ppc64le.rpm
-    repoid: ubi-8-baseos-rpms
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 149460
     checksum: sha256:077aa35cfe795d8d0816c0b79083c1e65bbcb52ae3ccca4621ac3cc7c03f7297
     name: patch
     evr: 2.7.6-11.el8
     sourcerpm: patch-2.7.6-11.el8.src.rpm
   source:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/source/SRPMS/Packages/o/openssl-1.1.1k-14.el8_6.src.rpm
-    repoid: ubi-8-baseos-source
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/source/SRPMS/Packages/o/openssl-1.1.1k-14.el8_6.src.rpm
+    repoid: ubi-8-for-x86_64-baseos-source-rpms
     size: 7741480
     checksum: sha256:c97b10d6a034e025a19ec8443ef7c80755e3a407fe29a77dda95af958b199eed
     name: openssl
     evr: 1:1.1.1k-14.el8_6
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/source/SRPMS/Packages/p/patch-2.7.6-11.el8.src.rpm
-    repoid: ubi-8-baseos-source
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/source/SRPMS/Packages/p/patch-2.7.6-11.el8.src.rpm
+    repoid: ubi-8-for-x86_64-baseos-source-rpms
     size: 818532
     checksum: sha256:1dbc060aa6adf18b5269f0f878ebf26a4b3da0edd92b3bc2c152072b9ba72b61
     name: patch
@@ -65,28 +65,28 @@ arches:
 - arch: s390x
   packages:
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/o/openssl-1.1.1k-14.el8_6.s390x.rpm
-    repoid: ubi-8-baseos-rpms
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 714804
     checksum: sha256:2f7e70c08d50e1f6314e5d130d77c6285e3133c57903ee692e49579ecf09963b
     name: openssl
     evr: 1:1.1.1k-14.el8_6
     sourcerpm: openssl-1.1.1k-14.el8_6.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/patch-2.7.6-11.el8.s390x.rpm
-    repoid: ubi-8-baseos-rpms
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 140820
     checksum: sha256:339df31fc25d8c0a542d3d71f99c2644327ae6bc5de383f2c77dbb70ef1846b1
     name: patch
     evr: 2.7.6-11.el8
     sourcerpm: patch-2.7.6-11.el8.src.rpm
   source:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/source/SRPMS/Packages/o/openssl-1.1.1k-14.el8_6.src.rpm
-    repoid: ubi-8-baseos-source
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/source/SRPMS/Packages/o/openssl-1.1.1k-14.el8_6.src.rpm
+    repoid: ubi-8-for-x86_64-baseos-source-rpms
     size: 7741480
     checksum: sha256:c97b10d6a034e025a19ec8443ef7c80755e3a407fe29a77dda95af958b199eed
     name: openssl
     evr: 1:1.1.1k-14.el8_6
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/source/SRPMS/Packages/p/patch-2.7.6-11.el8.src.rpm
-    repoid: ubi-8-baseos-source
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/source/SRPMS/Packages/p/patch-2.7.6-11.el8.src.rpm
+    repoid: ubi-8-for-x86_64-baseos-source-rpms
     size: 818532
     checksum: sha256:1dbc060aa6adf18b5269f0f878ebf26a4b3da0edd92b3bc2c152072b9ba72b61
     name: patch
@@ -95,14 +95,14 @@ arches:
 - arch: x86_64
   packages:
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/o/openssl-1.1.1k-14.el8_6.x86_64.rpm
-    repoid: ubi-8-baseos-rpms
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 728108
     checksum: sha256:a8e4ff3346cfa24713f54d2a9e2b53ad7f3c9d84a6c639ba2150b7cb09550af0
     name: openssl
     evr: 1:1.1.1k-14.el8_6
     sourcerpm: openssl-1.1.1k-14.el8_6.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/patch-2.7.6-11.el8.x86_64.rpm
-    repoid: ubi-8-baseos-rpms
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 141384
     checksum: sha256:7962e7045eb9f550a7e0e385ebecb831c679b8a844354e05f53aec3c10cd3f31
     name: patch
@@ -110,13 +110,13 @@ arches:
     sourcerpm: patch-2.7.6-11.el8.src.rpm
   source:
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/source/SRPMS/Packages/o/openssl-1.1.1k-14.el8_6.src.rpm
-    repoid: ubi-8-baseos-source
+    repoid: ubi-8-for-x86_64-baseos-source-rpms
     size: 7741480
     checksum: sha256:c97b10d6a034e025a19ec8443ef7c80755e3a407fe29a77dda95af958b199eed
     name: openssl
     evr: 1:1.1.1k-14.el8_6
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/source/SRPMS/Packages/p/patch-2.7.6-11.el8.src.rpm
-    repoid: ubi-8-baseos-source
+    repoid: ubi-8-for-x86_64-baseos-source-rpms
     size: 818532
     checksum: sha256:1dbc060aa6adf18b5269f0f878ebf26a4b3da0edd92b3bc2c152072b9ba72b61
     name: patch

--- a/ubi8.repo
+++ b/ubi8.repo
@@ -47,25 +47,10 @@ enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[codeready-builder-for-ubi-8-x86_64-rpms]
-name = Red Hat Universal Base Image 8 (RPMs) - CodeReady Builder
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/codeready-builder/os
-enabled = 0
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-gpgcheck = 1
-
-
 [codeready-builder-for-ubi-8-x86_64-debug-rpms]
 name = Red Hat Universal Base Image 8 (Debug RPMs) - CodeReady Builder
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/codeready-builder/debug
 enabled = 0
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-gpgcheck = 1
-
-[codeready-builder-for-ubi-8-x86_64-rpms]
-name = Red Hat Universal Base Image 8 (Source RPMs) - CodeReady Builder
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/codeready-builder/source/SRPMS
-enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
@@ -118,25 +103,10 @@ enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[codeready-builder-for-ubi-8-aarch64-rpms]
-name = Red Hat Universal Base Image 8 (RPMs) - CodeReady Builder
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/codeready-builder/os
-enabled = 0
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-gpgcheck = 1
-
-
 [codeready-builder-for-ubi-8-aarch64-debug-rpms]
 name = Red Hat Universal Base Image 8 (Debug RPMs) - CodeReady Builder
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/codeready-builder/debug
 enabled = 0
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-gpgcheck = 1
-
-[codeready-builder-for-ubi-8-aarch64-rpms]
-name = Red Hat Universal Base Image 8 (Source RPMs) - CodeReady Builder
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/codeready-builder/source/SRPMS
-enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
@@ -189,25 +159,10 @@ enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[codeready-builder-for-ubi-8-s390x-rpms]
-name = Red Hat Universal Base Image 8 (RPMs) - CodeReady Builder
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/codeready-builder/os
-enabled = 0
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-gpgcheck = 1
-
-
 [codeready-builder-for-ubi-8-s390x-debug-rpms]
 name = Red Hat Universal Base Image 8 (Debug RPMs) - CodeReady Builder
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/codeready-builder/debug
 enabled = 0
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-gpgcheck = 1
-
-[codeready-builder-for-ubi-8-s390x-rpms]
-name = Red Hat Universal Base Image 8 (Source RPMs) - CodeReady Builder
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/codeready-builder/source/SRPMS
-enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
@@ -260,14 +215,6 @@ enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[codeready-builder-for-ubi-8-ppc64le-rpms]
-name = Red Hat Universal Base Image 8 (RPMs) - CodeReady Builder
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/codeready-builder/os
-enabled = 0
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-gpgcheck = 1
-
-
 [codeready-builder-for-ubi-8-ppc64le-debug-rpms]
 name = Red Hat Universal Base Image 8 (Debug RPMs) - CodeReady Builder
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/codeready-builder/debug
@@ -275,9 +222,3 @@ enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[codeready-builder-for-ubi-8-ppc64le-rpms]
-name = Red Hat Universal Base Image 8 (Source RPMs) - CodeReady Builder
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/codeready-builder/source/SRPMS
-enabled = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-gpgcheck = 1

--- a/ubi8.repo
+++ b/ubi8.repo
@@ -1,70 +1,283 @@
-[ubi-8-baseos-rpms]
+[ubi-8-for-x86_64-baseos-rpms]
 name = Red Hat Universal Base Image 8 (RPMs) - BaseOS
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/os
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-baseos-debug-rpms]
+[ubi-8-for-x86_64-baseos-debug-rpms]
 name = Red Hat Universal Base Image 8 (Debug RPMs) - BaseOS
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/debug
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/debug
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-baseos-source]
+[ubi-8-for-x86_64-baseos-source-rpms]
 name = Red Hat Universal Base Image 8 (Source RPMs) - BaseOS
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/source/SRPMS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/source/SRPMS
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-appstream-rpms]
+[ubi-8-for-x86_64-appstream-rpms]
 name = Red Hat Universal Base Image 8 (RPMs) - AppStream
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/appstream/os
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-appstream-debug-rpms]
+[ubi-8-for-x86_64-appstream-debug-rpms]
 name = Red Hat Universal Base Image 8 (Debug RPMs) - AppStream
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/appstream/debug
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/debug
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-appstream-source]
+[ubi-8-for-x86_64-appstream-source-rpms]
 name = Red Hat Universal Base Image 8 (Source RPMs) - AppStream
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/appstream/source/SRPMS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/source/SRPMS
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-codeready-builder-rpms]
+[codeready-builder-for-ubi-8-x86_64-rpms]
 name = Red Hat Universal Base Image 8 (RPMs) - CodeReady Builder
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/codeready-builder/os
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/codeready-builder/os
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-codeready-builder]
+[codeready-builder-for-ubi-8-x86_64-rpms]
 name = Red Hat Universal Base Image 8 (RPMs) - CodeReady Builder
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/codeready-builder/os
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/codeready-builder/os
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
 
-[ubi-8-codeready-builder-debug-rpms]
+[codeready-builder-for-ubi-8-x86_64-debug-rpms]
 name = Red Hat Universal Base Image 8 (Debug RPMs) - CodeReady Builder
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/codeready-builder/debug
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/codeready-builder/debug
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-codeready-builder-source]
+[codeready-builder-for-ubi-8-x86_64-rpms]
 name = Red Hat Universal Base Image 8 (Source RPMs) - CodeReady Builder
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/codeready-builder/source/SRPMS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/codeready-builder/source/SRPMS
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-for-aarch64-baseos-rpms]
+name = Red Hat Universal Base Image 8 (RPMs) - BaseOS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-for-aarch64-baseos-debug-rpms]
+name = Red Hat Universal Base Image 8 (Debug RPMs) - BaseOS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-for-aarch64-baseos-source-rpms]
+name = Red Hat Universal Base Image 8 (Source RPMs) - BaseOS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/source/SRPMS
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-for-aarch64-appstream-rpms]
+name = Red Hat Universal Base Image 8 (RPMs) - AppStream
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-for-aarch64-appstream-debug-rpms]
+name = Red Hat Universal Base Image 8 (Debug RPMs) - AppStream
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-for-aarch64-appstream-source-rpms]
+name = Red Hat Universal Base Image 8 (Source RPMs) - AppStream
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/source/SRPMS
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[codeready-builder-for-ubi-8-aarch64-rpms]
+name = Red Hat Universal Base Image 8 (RPMs) - CodeReady Builder
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/codeready-builder/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[codeready-builder-for-ubi-8-aarch64-rpms]
+name = Red Hat Universal Base Image 8 (RPMs) - CodeReady Builder
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/codeready-builder/os
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+
+[codeready-builder-for-ubi-8-aarch64-debug-rpms]
+name = Red Hat Universal Base Image 8 (Debug RPMs) - CodeReady Builder
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/codeready-builder/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[codeready-builder-for-ubi-8-aarch64-rpms]
+name = Red Hat Universal Base Image 8 (Source RPMs) - CodeReady Builder
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/codeready-builder/source/SRPMS
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-for-s390x-baseos-rpms]
+name = Red Hat Universal Base Image 8 (RPMs) - BaseOS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-for-s390x-baseos-debug-rpms]
+name = Red Hat Universal Base Image 8 (Debug RPMs) - BaseOS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-for-s390x-baseos-source-rpms]
+name = Red Hat Universal Base Image 8 (Source RPMs) - BaseOS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/source/SRPMS
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-for-s390x-appstream-rpms]
+name = Red Hat Universal Base Image 8 (RPMs) - AppStream
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-for-s390x-appstream-debug-rpms]
+name = Red Hat Universal Base Image 8 (Debug RPMs) - AppStream
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-for-s390x-appstream-source-rpms]
+name = Red Hat Universal Base Image 8 (Source RPMs) - AppStream
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/source/SRPMS
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[codeready-builder-for-ubi-8-s390x-rpms]
+name = Red Hat Universal Base Image 8 (RPMs) - CodeReady Builder
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/codeready-builder/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[codeready-builder-for-ubi-8-s390x-rpms]
+name = Red Hat Universal Base Image 8 (RPMs) - CodeReady Builder
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/codeready-builder/os
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+
+[codeready-builder-for-ubi-8-s390x-debug-rpms]
+name = Red Hat Universal Base Image 8 (Debug RPMs) - CodeReady Builder
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/codeready-builder/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[codeready-builder-for-ubi-8-s390x-rpms]
+name = Red Hat Universal Base Image 8 (Source RPMs) - CodeReady Builder
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/codeready-builder/source/SRPMS
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-for-ppc64le-baseos-rpms]
+name = Red Hat Universal Base Image 8 (RPMs) - BaseOS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-for-ppc64le-baseos-debug-rpms]
+name = Red Hat Universal Base Image 8 (Debug RPMs) - BaseOS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-for-ppc64le-baseos-source-rpms]
+name = Red Hat Universal Base Image 8 (Source RPMs) - BaseOS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/source/SRPMS
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-for-ppc64le-appstream-rpms]
+name = Red Hat Universal Base Image 8 (RPMs) - AppStream
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-for-ppc64le-appstream-debug-rpms]
+name = Red Hat Universal Base Image 8 (Debug RPMs) - AppStream
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-for-ppc64le-appstream-source-rpms]
+name = Red Hat Universal Base Image 8 (Source RPMs) - AppStream
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/source/SRPMS
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[codeready-builder-for-ubi-8-ppc64le-rpms]
+name = Red Hat Universal Base Image 8 (RPMs) - CodeReady Builder
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/codeready-builder/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[codeready-builder-for-ubi-8-ppc64le-rpms]
+name = Red Hat Universal Base Image 8 (RPMs) - CodeReady Builder
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/codeready-builder/os
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+
+[codeready-builder-for-ubi-8-ppc64le-debug-rpms]
+name = Red Hat Universal Base Image 8 (Debug RPMs) - CodeReady Builder
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/codeready-builder/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[codeready-builder-for-ubi-8-ppc64le-rpms]
+name = Red Hat Universal Base Image 8 (Source RPMs) - CodeReady Builder
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/codeready-builder/source/SRPMS
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1


### PR DESCRIPTION
This update changes the rpm repository ids to match those found in Red Hat's [repository-to-cpe.json](https://security.access.redhat.com/data/meta/v1/repository-to-cpe.json) mapping file, used by third-party scanners.

In order for scanners like clair to understand what [CPE](https://cpe.mitre.org/) a Red Hat rpm is associated with, it needs to be able to find its repository in Red Hat's published mapping file.

Even though some "arch-less" repository ids currently appear in the mapping file, they are going to be removed soon and will be blocked by Konflux in the future in https://github.com/release-engineering/rhtap-ec-policy/pull/99.