### PR TITLE
Configure RPM prefetch for jaeger-all-in-one and jaeger-query

### DIFF
--- a/.tekton/jaeger-all-in-one-pull-request.yaml
+++ b/.tekton/jaeger-all-in-one-pull-request.yaml
@@ -35,7 +35,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: prefetch-input
-    value: '[{"type": "gomod", "path": "./jaeger"}, {"type": "npm", "path": "./jaeger-ui"}]'
+    value: '[{"type": "gomod", "path": "./jaeger"}, {"type": "npm", "path": "./jaeger-ui"}, {"type": "rpm"}]'
   - name: hermetic
     value: "true"
   - name: output-image

--- a/.tekton/jaeger-all-in-one-pull-request.yaml
+++ b/.tekton/jaeger-all-in-one-pull-request.yaml
@@ -36,6 +36,8 @@ spec:
     value: '{{revision}}'
   - name: prefetch-input
     value: '[{"type": "gomod", "path": "./jaeger"}, {"type": "npm", "path": "./jaeger-ui"}, {"type": "rpm"}]'
+  - name: prefetch-dev-package-managers-enabled
+    value: "true"
   - name: hermetic
     value: "true"
   - name: output-image

--- a/.tekton/jaeger-all-in-one-push.yaml
+++ b/.tekton/jaeger-all-in-one-push.yaml
@@ -35,7 +35,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: prefetch-input
-    value: '[{"type": "gomod", "path": "./jaeger"}, {"type": "npm", "path": "./jaeger-ui"}]'
+    value: '[{"type": "gomod", "path": "./jaeger"}, {"type": "npm", "path": "./jaeger-ui"}, {"type": "rpm"}]'
   - name: hermetic
     value: "true"
   - name: output-image

--- a/.tekton/jaeger-all-in-one-push.yaml
+++ b/.tekton/jaeger-all-in-one-push.yaml
@@ -36,6 +36,8 @@ spec:
     value: '{{revision}}'
   - name: prefetch-input
     value: '[{"type": "gomod", "path": "./jaeger"}, {"type": "npm", "path": "./jaeger-ui"}, {"type": "rpm"}]'
+  - name: prefetch-dev-package-managers-enabled
+    value: "true"
   - name: hermetic
     value: "true"
   - name: output-image

--- a/.tekton/jaeger-query-pull-request.yaml
+++ b/.tekton/jaeger-query-pull-request.yaml
@@ -35,7 +35,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: prefetch-input
-    value: '[{"type": "gomod", "path": "./jaeger"}, {"type": "npm", "path": "./jaeger-ui"}]'
+    value: '[{"type": "gomod", "path": "./jaeger"}, {"type": "npm", "path": "./jaeger-ui"}, {"type": "rpm"}]'
   - name: hermetic
     value: "true"
   - name: output-image

--- a/.tekton/jaeger-query-pull-request.yaml
+++ b/.tekton/jaeger-query-pull-request.yaml
@@ -36,6 +36,8 @@ spec:
     value: '{{revision}}'
   - name: prefetch-input
     value: '[{"type": "gomod", "path": "./jaeger"}, {"type": "npm", "path": "./jaeger-ui"}, {"type": "rpm"}]'
+  - name: prefetch-dev-package-managers-enabled
+    value: "true"
   - name: hermetic
     value: "true"
   - name: output-image

--- a/.tekton/jaeger-query-push.yaml
+++ b/.tekton/jaeger-query-push.yaml
@@ -35,7 +35,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: prefetch-input
-    value: '[{"type": "gomod", "path": "./jaeger"}, {"type": "npm", "path": "./jaeger-ui"}]'
+    value: '[{"type": "gomod", "path": "./jaeger"}, {"type": "npm", "path": "./jaeger-ui"}, {"type": "rpm"}]'
   - name: hermetic
     value: "true"
   - name: output-image

--- a/.tekton/jaeger-query-push.yaml
+++ b/.tekton/jaeger-query-push.yaml
@@ -36,6 +36,8 @@ spec:
     value: '{{revision}}'
   - name: prefetch-input
     value: '[{"type": "gomod", "path": "./jaeger"}, {"type": "npm", "path": "./jaeger-ui"}, {"type": "rpm"}]'
+  - name: prefetch-dev-package-managers-enabled
+    value: "true"
   - name: hermetic
     value: "true"
   - name: output-image


### PR DESCRIPTION
We need to install the `patch` tool for the Jaeger deprecation banner.