### PR TITLE
Update image reference in bundle to use prod registry

### DIFF
--- a/Dockerfile.bundle
+++ b/Dockerfile.bundle
@@ -18,7 +18,7 @@ RUN ls manifests -al
 RUN ls metadata -al
 
 # stage - registry.stage.redhat.io, prod - registry.redhat.io
-ARG REGISTRY=quay.io/redhat-user-workloads
+ARG REGISTRY=registry.redhat.io
 
 RUN ./update_bundle.sh && cat manifests/jaeger-operator.clusterserviceversion.yaml metadata/annotations.yaml
 


### PR DESCRIPTION
Our test pipelines check the operator csv to make sure the images are referenced using registry.redhat.io instead of quay. The PR fixes the image reference in bundle to always use prod registry.