### PR TITLE
add schema to renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,5 @@
 {
-  "extends": [
-    "github>konflux-ci/mintmaker//config/renovate/renovate.json"
-  ],
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "ignoreDeps": [
     "registry.redhat.io/openshift4/ose-operator-registry",
     "registry.redhat.io/openshift4/ose-operator-registry-rhel9"


### PR DESCRIPTION
* add $schema to renovate.json
* do not extend from base config. MintMaker already extends from the base config implicitly, and by linking to the main branch directly we could include configs which are not deployed yet.

Ref. https://konflux.pages.redhat.com/docs/users/mintmaker/user.html#create-your-custom-configuration