### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for jaeger-operator-main

### DIFF
--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -43,4 +43,5 @@ LABEL com.redhat.component="jaeger-operator-container" \
       io.k8s.description="Operator for the Jaeger." \
       io.openshift.expose-services="" \
       io.openshift.tags="tracing" \
-      io.k8s.display-name="Jaeger Operator"
+      io.k8s.display-name="Jaeger Operator" \
+      cpe="cpe:/a:redhat:openshift_distributed_tracing:3.6::el8"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
