### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for jaeger-query-main

### DIFF
--- a/Dockerfile.query
+++ b/Dockerfile.query
@@ -59,4 +59,5 @@ LABEL com.redhat.component="jaeger-query-container" \
       io.k8s.description="Query for the distributed tracing system." \
       io.openshift.expose-services="16686:uihttp" \
       io.openshift.tags="tracing" \
-      io.k8s.display-name="Jaeger Query"
+      io.k8s.display-name="Jaeger Query" \
+      cpe="cpe:/a:redhat:openshift_distributed_tracing:3.6::el8"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
