### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for jaeger-bundle-main

### DIFF
--- a/Dockerfile.bundle
+++ b/Dockerfile.bundle
@@ -51,6 +51,7 @@ LABEL release="1.65.0-4" \
       io.k8s.description="Bundle for Jaeger operator." \
       # TODO check if this is correct
       com.redhat.component="rhosdt" \
+      cpe="cpe:/a:redhat:openshift_distributed_tracing:3.6::el8" \
       io.openshift.tags="tracing" \
       io.k8s.display-name="Jaeger Operator Bundle" \
       url="https://github.com/jaegertracing/jaeger-operator" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
