### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for jaeger-ingester-main

### DIFF
--- a/Dockerfile.ingester
+++ b/Dockerfile.ingester
@@ -34,6 +34,7 @@ ENTRYPOINT ["/usr/bin/jaeger"]
 
 LABEL com.redhat.component="jaeger-ingester-container" \
       name="rhosdt/jaeger-ingester-rhel8" \
+      cpe="cpe:/a:redhat:openshift_distributed_tracing:3.6::el8" \
       summary="Jaeger Ingester" \
       description="Ingester for the distributed tracing system" \
       io.k8s.description="Ingester for the distributed tracing system." \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
