### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for jaeger-es-rollover-main

### DIFF
--- a/Dockerfile.esrollover
+++ b/Dockerfile.esrollover
@@ -34,4 +34,5 @@ LABEL com.redhat.component="jaeger-es-rollover-container" \
       io.k8s.description="Index rollover for the distributed tracing system." \
       io.openshift.expose-services="" \
       io.openshift.tags="tracing" \
-      io.k8s.display-name="Jaeger ES rollover"
+      io.k8s.display-name="Jaeger ES rollover" \
+      cpe="cpe:/a:redhat:openshift_distributed_tracing:3.6::el8"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
