### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for jaeger-collector-main

### DIFF
--- a/Dockerfile.collector
+++ b/Dockerfile.collector
@@ -31,7 +31,8 @@ ARG USER_UID=1001
 USER ${USER_UID}
 ENTRYPOINT ["/usr/bin/jaeger"]
 
-LABEL com.redhat.component="jaeger-collector-container" \
+LABEL cpe="cpe:/a:redhat:openshift_distributed_tracing:3.6::el8" \
+      com.redhat.component="jaeger-collector-container" \
       name="rhosdt/jaeger-collector-rhel8" \
       summary="Jaeger Collector" \
       description="Collector for the distributed tracing system" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
