### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for jaeger-all-in-one-main

### DIFF
--- a/Dockerfile.allinone
+++ b/Dockerfile.allinone
@@ -53,6 +53,7 @@ USER ${USER_UID}
 ENTRYPOINT ["/usr/bin/jaeger"]
 
 LABEL com.redhat.component="jaeger-all-in-one-container" \
+      cpe="cpe:/a:redhat:openshift_distributed_tracing:3.6::el8" \
       name="rhosdt/jaeger-all-in-one-rhel8" \
       summary="Jaeger all-in-one" \
       description="All-in-one for the distributed tracing system" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
