### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for jaeger-agent-main

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -39,4 +39,5 @@ LABEL com.redhat.component="jaeger-agent-container" \
       io.k8s.description="Agent for the distributed tracing system." \
       io.openshift.expose-services="5775/udp:zipkincompact,6831/udp:compact,6832/udp:binary,5778:config" \
       io.openshift.tags="tracing" \
-      io.k8s.display-name="Jaeger agent"
+      io.k8s.display-name="Jaeger agent" \
+      cpe="cpe:/a:redhat:openshift_distributed_tracing:3.6::el8"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
